### PR TITLE
feat(string-validation): Convert number and boolean field values to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ iex> Litmus.validate(params, schema)
 
 ### Litmus.Type.String
 
-The `String` module contains options that will validate String data types. It converts `boolean` and `number` data to type `string`. It supports the following options:
+The `String` module contains options that will validate String data types. It converts boolean and number values to strings. It supports the following options:
   * `:min_length` - Specifies the minimum number of characters needed in the string. Allowed values are non-negative integers.
   * `:max_length` - Specifies the maximum number of characters needed in the string. Allowed values are non-negative integers.
   * `:length` - Specifies the exact number of characters needed in the string. Allowed values are non-negative integers.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ iex> Litmus.validate(params, schema)
 
 ### Litmus.Type.String
 
-The `String` module contains options that will validate String data types. It supports the following options:
+The `String` module contains options that will validate String data types. It converts `boolean` and `number` data to type `string`. It supports the following options:
   * `:min_length` - Specifies the minimum number of characters needed in the string. Allowed values are non-negative integers.
   * `:max_length` - Specifies the maximum number of characters needed in the string. Allowed values are non-negative integers.
   * `:length` - Specifies the exact number of characters needed in the string. Allowed values are non-negative integers.

--- a/lib/type/string.ex
+++ b/lib/type/string.ex
@@ -39,33 +39,21 @@ defmodule Litmus.Type.String do
 
   @spec convert(t, binary, map) :: {:ok, map}
   defp convert(%__MODULE__{}, field, params) do
-    if Map.has_key?(params, field) and
-         !(is_binary(params[field]) or is_number(params[field]) or is_boolean(params[field])) do
-      {:error, "#{field} must be string"}
-    else
-      if is_binary(params[field]) do
+    cond do
+      is_binary(params[field]) ->
         {:ok, params}
-      else
+
+      is_number(params[field]) or is_boolean(params[field]) ->
         modified_value = Kernel.inspect(params[field])
         modified_params = Map.put(params, field, modified_value)
         {:ok, modified_params}
-      end
-    end
-  end
 
-  @spec trim(t, binary, map) :: {:ok, map}
-  defp trim(%__MODULE__{trim: true}, field, params) do
-    if Map.has_key?(params, field) do
-      trimmed_value = String.trim(params[field])
-      trimmed_params = Map.put(params, field, trimmed_value)
-      {:ok, trimmed_params}
-    else
-      {:ok, params}
-    end
-  end
+      Map.has_key?(params, field) ->
+        {:error, "#{field} must be string"}
 
-  defp trim(%__MODULE__{trim: false}, _field, params) do
-    {:ok, params}
+      true ->
+        {:ok, params}
+    end
   end
 
   @spec min_length_validate(t, binary, map) :: {:ok, map} | {:error, binary}
@@ -122,6 +110,21 @@ defmodule Litmus.Type.String do
     else
       {:ok, params}
     end
+  end
+
+  @spec trim(t, binary, map) :: {:ok, map}
+  defp trim(%__MODULE__{trim: true}, field, params) do
+    if Map.has_key?(params, field) do
+      trimmed_value = String.trim(params[field])
+      trimmed_params = Map.put(params, field, trimmed_value)
+      {:ok, trimmed_params}
+    else
+      {:ok, params}
+    end
+  end
+
+  defp trim(%__MODULE__{trim: false}, _field, params) do
+    {:ok, params}
   end
 
   defimpl Litmus.Type do

--- a/lib/type/string.ex
+++ b/lib/type/string.ex
@@ -40,19 +40,19 @@ defmodule Litmus.Type.String do
   @spec convert(t, binary, map) :: {:ok, map}
   defp convert(%__MODULE__{}, field, params) do
     cond do
+      !Map.has_key?(params, field) ->
+        {:ok, params}
+
       is_binary(params[field]) ->
         {:ok, params}
 
       is_number(params[field]) or is_boolean(params[field]) ->
-        modified_value = Kernel.inspect(params[field])
+        modified_value = to_string(params[field])
         modified_params = Map.put(params, field, modified_value)
         {:ok, modified_params}
 
-      Map.has_key?(params, field) ->
-        {:error, "#{field} must be string"}
-
       true ->
-        {:ok, params}
+        {:error, "#{field} must be string"}
     end
   end
 

--- a/lib/type/string.ex
+++ b/lib/type/string.ex
@@ -124,8 +124,6 @@ defmodule Litmus.Type.String do
     end
   end
 
-
-
   defimpl Litmus.Type do
     alias Litmus.Type
 

--- a/lib/type/string.ex
+++ b/lib/type/string.ex
@@ -47,9 +47,7 @@ defmodule Litmus.Type.String do
         {:ok, params}
 
       is_number(params[field]) or is_boolean(params[field]) ->
-        modified_value = to_string(params[field])
-        modified_params = Map.put(params, field, modified_value)
-        {:ok, modified_params}
+        {:ok, Map.update!(params, field, &to_string/1)}
 
       true ->
         {:error, "#{field} must be string"}

--- a/test/litmus_test.exs
+++ b/test/litmus_test.exs
@@ -23,7 +23,8 @@ defmodule LitmusTest do
           length: 4,
           required: true,
           trim: true
-        }
+        },
+        "field1" => %Litmus.Type.String{}
       }
 
       req_params = %{

--- a/test/litmus_test.exs
+++ b/test/litmus_test.exs
@@ -23,8 +23,7 @@ defmodule LitmusTest do
           length: 4,
           required: true,
           trim: true
-        },
-        "dob" => %Litmus.Type.String{}
+        }
       }
 
       req_params = %{

--- a/test/litmus_test.exs
+++ b/test/litmus_test.exs
@@ -24,7 +24,7 @@ defmodule LitmusTest do
           required: true,
           trim: true
         },
-        "field1" => %Litmus.Type.String{}
+        "dob" => %Litmus.Type.String{}
       }
 
       req_params = %{

--- a/test/type/string_test.exs
+++ b/test/type/string_test.exs
@@ -193,11 +193,7 @@ defmodule Litmus.Type.StringTest do
       modified_data = %{"id" => "1", "new_user" => "true"}
 
       schema = %{
-        "id" => %Litmus.Type.String{
-          regex: %Litmus.Type.String.Regex{
-            pattern: ~r/^[0-9]+$/
-          }
-        },
+        "id" => %Litmus.Type.String{},
         "new_user" => %Litmus.Type.String{}
       }
 

--- a/test/type/string_test.exs
+++ b/test/type/string_test.exs
@@ -191,15 +191,14 @@ defmodule Litmus.Type.StringTest do
     test "returns :ok with new parameters having values converted to string when field is boolean or number" do
       data = %{"id" => 1, "new_user" => true}
       modified_data = %{"id" => "1", "new_user" => "true"}
-      data_1 = %{}
 
       schema = %{
         "id" => %Litmus.Type.String{},
-        "new_user" => %Litmus.Type.String{}
+        "new_user" => %Litmus.Type.String{},
+        "description" => %Litmus.Type.String{}
       }
 
       assert Litmus.validate(data, schema) == {:ok, modified_data}
-      assert Litmus.validate(data_1, schema) == {:ok, data_1}
     end
 
     test "returns :error when field is neither string nor boolean nor number" do

--- a/test/type/string_test.exs
+++ b/test/type/string_test.exs
@@ -186,4 +186,32 @@ defmodule Litmus.Type.StringTest do
       assert Litmus.validate(data, schema) == {:ok, data}
     end
   end
+
+  describe "convert to string" do
+    test "returns :ok with new parameters having values converted to string when field is boolean or number" do
+      data = %{"id" => 1, "new_user" => true}
+      modified_data = %{"id" => "1", "new_user" => "true"}
+
+      schema = %{
+        "id" => %Litmus.Type.String{
+          regex: %Litmus.Type.String.Regex{
+            pattern: ~r/^[0-9]+$/
+          }
+        },
+        "new_user" => %Litmus.Type.String{}
+      }
+
+      assert Litmus.validate(data, schema) == {:ok, modified_data}
+    end
+
+    test "returns :error when field is neither string nor boolean nor number" do
+      data = %{"id" => ["1"]}
+
+      schema = %{
+        "id" => %Litmus.Type.String{}
+      }
+
+      assert Litmus.validate(data, schema) == {:error, "id must be string"}
+    end
+  end
 end

--- a/test/type/string_test.exs
+++ b/test/type/string_test.exs
@@ -191,6 +191,7 @@ defmodule Litmus.Type.StringTest do
     test "returns :ok with new parameters having values converted to string when field is boolean or number" do
       data = %{"id" => 1, "new_user" => true}
       modified_data = %{"id" => "1", "new_user" => "true"}
+      data_1 = %{}
 
       schema = %{
         "id" => %Litmus.Type.String{},
@@ -198,6 +199,7 @@ defmodule Litmus.Type.StringTest do
       }
 
       assert Litmus.validate(data, schema) == {:ok, modified_data}
+      assert Litmus.validate(data_1, schema) == {:ok, data_1}
     end
 
     test "returns :error when field is neither string nor boolean nor number" do


### PR DESCRIPTION
### What
* Convert `Number` and `Boolean` field values to type `String`.

### Why
* Giving number or boolean values in string schema will not throw an error. It will be converted to string type.