### PR TITLE
fix(boolean): simplifies check_booelan_values return

### DIFF
--- a/lib/type/boolean.ex
+++ b/lib/type/boolean.ex
@@ -39,11 +39,11 @@ defmodule Litmus.Type.Boolean do
         end
       end)
 
-    if String.downcase(initial_value) in allowed_values, do: true, else: false
+    String.downcase(initial_value) in allowed_values
   end
 
   defp check_boolean_values(initial_value, additional_values, default_values) do
-    if initial_value in Enum.uniq(additional_values ++ default_values), do: true
+    initial_value in Enum.uniq(additional_values ++ default_values)
   end
 
   @spec truthy_falsy_validate(t, binary, map) :: {:ok, map} | {:error, binary}


### PR DESCRIPTION
No need for `if`s here. In the second line changed, it was actually returning `true | nil` which didn't match the return type.