### PR TITLE
chore(spec): changes binary to String.t()

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ iex> Litmus.validate(params, schema)
 ### Litmus.Type.Boolean
 
 The `Boolean` module contains options that will validate Boolean data types. It converts truthy and falsy values to `true` or `false`. It supports the following options:
-  * `:truthy` - Allows additional values, i.e. truthy values to be considered valid booleans by converting them to `true` during validation. Allowed value is an array of binary, number or boolean values. The default is `[true, "true"]`
-  * `:falsy` - Allows additional values, i.e. falsy values to be considered valid booleans by converting them to `false` during validation. Allowed value is an array of binary, number or boolean values. The default is `[false, "false"]`
+  * `:truthy` - Allows additional values, i.e. truthy values to be considered valid booleans by converting them to `true` during validation. Allowed value is an array of strings, number or boolean values. The default is `[true, "true"]`
+  * `:falsy` - Allows additional values, i.e. falsy values to be considered valid booleans by converting them to `false` during validation. Allowed value is an array of strings, number or boolean values. The default is `[false, "false"]`
 
 ```
 iex> schema = %{
@@ -126,7 +126,7 @@ The `String` module contains options that will validate String data types. It co
   * `:min_length` - Specifies the minimum number of characters needed in the string. Allowed values are non-negative integers.
   * `:max_length` - Specifies the maximum number of characters needed in the string. Allowed values are non-negative integers.
   * `:length` - Specifies the exact number of characters needed in the string. Allowed values are non-negative integers.
-  * `:regex` - Specifies a Regular expression that a string must match. Allowed value is a struct consisting of `pattern` and `error_message`, where `pattern` is a `Regex` and `error_message` is a `binary` value. Default value for pattern is `nil`. If no error_message is given, the default message returned on error is `"#{field} must be in a valid format"`.
+  * `:regex` - Specifies a Regular expression that a string must match. Allowed value is a struct consisting of `pattern` and `error_message`, where `pattern` is a `Regex` and `error_message` is a `String.t()` value. Default value for pattern is `nil`. If no error_message is given, the default message returned on error is `"#{field} must be in a valid format"`.
   * `:trim` - Removes additional whitespaces in a string and returns the new value. Allowed values are `true` and `false`. The default is `false`.
 
 ```
@@ -155,4 +155,3 @@ iex> Litmus.validate(params, schema)
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/litmus](https://hexdocs.pm/litmus).
-

--- a/lib/litmus.ex
+++ b/lib/litmus.ex
@@ -6,7 +6,7 @@ defmodule Litmus do
   @doc """
   Validate data based on a schema.
   """
-  @spec validate(map, map) :: {:ok, map} | {:error, binary}
+  @spec validate(map, map) :: {:ok, map} | {:error, String.t()}
   def validate(data, schema) do
     case validate_allowed_params(data, schema) do
       :ok -> validate_schema(data, schema)
@@ -14,7 +14,7 @@ defmodule Litmus do
     end
   end
 
-  @spec validate_allowed_params(map, map) :: :ok | {:error, binary}
+  @spec validate_allowed_params(map, map) :: :ok | {:error, String.t()}
   defp validate_allowed_params(data, schema) do
     result = Map.keys(data) -- Map.keys(schema)
 
@@ -24,7 +24,7 @@ defmodule Litmus do
     end
   end
 
-  @spec validate_schema(map, map) :: {:ok, map} | {:error, binary}
+  @spec validate_schema(map, map) :: {:ok, map} | {:error, String.t()}
   defp validate_schema(data, schema) do
     Enum.reduce_while(schema, {:ok, data}, fn {field, type}, {:ok, modified_data} ->
       case Type.validate(type, field, modified_data) do

--- a/lib/required.ex
+++ b/lib/required.ex
@@ -1,7 +1,7 @@
 defmodule Litmus.Required do
   @moduledoc false
 
-  @spec validate(map, binary, map) :: {:ok, map} | {:error, binary}
+  @spec validate(map, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate(%{required: true}, field, params) do
     if Map.has_key?(params, field) do
       {:ok, params}

--- a/lib/type.ex
+++ b/lib/type.ex
@@ -5,6 +5,6 @@ defprotocol Litmus.Type do
 
   @type t :: Type.Any.t() | Type.Boolean.t() | Type.Number.t() | Type.String.t()
 
-  @spec validate(t(), binary, map) :: {:ok, map} | {:error, binary}
+  @spec validate(t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate(type, field, data)
 end

--- a/lib/type/any.ex
+++ b/lib/type/any.ex
@@ -9,13 +9,13 @@ defmodule Litmus.Type.Any do
           required: boolean
         }
 
-  @spec validate_field(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data), do: Required.validate(type, field, data)
 
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), binary, map) :: {:ok, map} | {:error, binary}
+    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.Any.validate_field(type, field, data)
   end
 end

--- a/lib/type/boolean.ex
+++ b/lib/type/boolean.ex
@@ -16,7 +16,7 @@ defmodule Litmus.Type.Boolean do
           required: boolean
         }
 
-  @spec validate_field(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
          {:ok, data} <- truthy_falsy_validate(type, field, data) do
@@ -46,7 +46,7 @@ defmodule Litmus.Type.Boolean do
     initial_value in Enum.uniq(additional_values ++ default_values)
   end
 
-  @spec truthy_falsy_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec truthy_falsy_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp truthy_falsy_validate(%__MODULE__{falsy: falsy, truthy: truthy}, field, params) do
     cond do
       !Map.has_key?(params, field) ->
@@ -66,7 +66,7 @@ defmodule Litmus.Type.Boolean do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), binary, map) :: {:ok, map} | {:error, binary}
+    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.Boolean.validate_field(type, field, data)
   end
 end

--- a/lib/type/string.ex
+++ b/lib/type/string.ex
@@ -22,7 +22,7 @@ defmodule Litmus.Type.String do
           required: boolean
         }
 
-  @spec validate_field(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
          {:ok, data} <- convert(type, field, data),
@@ -37,7 +37,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec convert(t, binary, map) :: {:ok, map}
+  @spec convert(t, String.t(), map) :: {:ok, map}
   defp convert(%__MODULE__{}, field, params) do
     cond do
       !Map.has_key?(params, field) ->
@@ -54,7 +54,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec min_length_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec min_length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp min_length_validate(%__MODULE__{min_length: nil}, _field, params) do
     {:ok, params}
   end
@@ -68,7 +68,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec max_length_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec max_length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp max_length_validate(%__MODULE__{max_length: nil}, _field, params) do
     {:ok, params}
   end
@@ -82,7 +82,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec length_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp length_validate(%__MODULE__{length: nil}, _field, params) do
     {:ok, params}
   end
@@ -96,7 +96,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec regex_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec regex_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp regex_validate(%__MODULE__{regex: %{pattern: nil}}, _field, params) do
     {:ok, params}
   end
@@ -110,7 +110,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec trim(t, binary, map) :: {:ok, map}
+  @spec trim(t, String.t(), map) :: {:ok, map}
   defp trim(%__MODULE__{trim: true}, field, params) do
     if Map.has_key?(params, field) do
       trimmed_value = String.trim(params[field])
@@ -128,7 +128,7 @@ defmodule Litmus.Type.String do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), binary, map) :: {:ok, map} | {:error, binary}
+    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.String.validate_field(type, field, data)
   end
 end


### PR DESCRIPTION
## What

* Change `binary` types to `String.t()` because they could contain unicode characters

## Notes

* Technically the `field`s specified shouldn't have to be `String.t()`, but for now I think this is the intended use case, so I already updated those to `String.t()` from `binary`.