### PR TITLE
fix(allow-nil): Convert nil value of data to empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ iex> Litmus.validate(params, schema)
 
 ### Litmus.Type.String
 
-The `String` module contains options that will validate String data types. It converts boolean and number values to strings. It supports the following options:
+The `String` module contains options that will validate String data types. It converts boolean and number values to strings. It will also convert `nil` value to empty string. It supports the following options:
   * `:min_length` - Specifies the minimum number of characters needed in the string. Allowed values are non-negative integers.
   * `:max_length` - Specifies the maximum number of characters needed in the string. Allowed values are non-negative integers.
   * `:length` - Specifies the exact number of characters needed in the string. Allowed values are non-negative integers.

--- a/lib/type/string.ex
+++ b/lib/type/string.ex
@@ -43,6 +43,9 @@ defmodule Litmus.Type.String do
       !Map.has_key?(params, field) ->
         {:ok, params}
 
+      is_nil(params[field]) ->
+        {:ok, Map.put(params, field, "")}
+
       is_binary(params[field]) ->
         {:ok, params}
 
@@ -50,7 +53,7 @@ defmodule Litmus.Type.String do
         {:ok, Map.update!(params, field, &to_string/1)}
 
       true ->
-        {:error, "#{field} must be string"}
+        {:error, "#{field} must be a string"}
     end
   end
 

--- a/test/type/string_test.exs
+++ b/test/type/string_test.exs
@@ -201,6 +201,17 @@ defmodule Litmus.Type.StringTest do
       assert Litmus.validate(data, schema) == {:ok, modified_data}
     end
 
+    test "returns :ok with parameter value converted to empty string if field is nil" do
+      data = %{"id" => nil}
+      modified_data = %{"id" => ""}
+
+      schema = %{
+        "id" => %Litmus.Type.String{}
+      }
+
+      assert Litmus.validate(data, schema) == {:ok, modified_data}
+    end
+
     test "returns :error when field is neither string nor boolean nor number" do
       data = %{"id" => ["1"]}
 
@@ -208,7 +219,7 @@ defmodule Litmus.Type.StringTest do
         "id" => %Litmus.Type.String{}
       }
 
-      assert Litmus.validate(data, schema) == {:error, "id must be string"}
+      assert Litmus.validate(data, schema) == {:error, "id must be a string"}
     end
   end
 end


### PR DESCRIPTION
### What
* Convert `nil` to `""`, if the data passed has nil value

### Why
* We want to allow nil as a value