### PR TITLE
feat(datetime): adds DateTime type

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Litmus currently supports the following types.
 
 * `Litmus.Type.Any`
 * `Litmus.Type.Boolean`
+* `Litmus.Type.DateTime`
 * `Litmus.Type.List`
 * `Litmus.Type.Number`
 * `Litmus.Type.String`

--- a/lib/litmus/type.ex
+++ b/lib/litmus/type.ex
@@ -3,7 +3,13 @@ defprotocol Litmus.Type do
 
   alias Litmus.Type
 
-  @type t :: Type.Any.t() | Type.Boolean.t() | Type.List.t() | Type.Number.t() | Type.String.t()
+  @type t ::
+          Type.Any.t()
+          | Type.Boolean.t()
+          | Type.DateTime.t()
+          | Type.List.t()
+          | Type.Number.t()
+          | Type.String.t()
 
   @spec validate(t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate(type, field, data)

--- a/lib/litmus/type/date_time.ex
+++ b/lib/litmus/type/date_time.ex
@@ -1,0 +1,71 @@
+defmodule Litmus.Type.DateTime do
+  @moduledoc """
+  This type validates and converts ISO-8601 datetime with timezone strings into
+  `DateTime`s.
+
+  ## Options
+
+    * `:required` - Setting `:required` to `true` will cause a validation error
+      when a field is not present or the value is `nil`. Allowed values for
+      required are `true` and `false`. The default is `false`.
+
+  ## Examples
+
+      iex> schema = %{"start_date" => %Litmus.Type.DateTime{}}
+      iex> {:ok, %{"start_date" => datetime}} = Litmus.validate(%{"start_date" => "2017-06-18T05:45:33Z"}, schema)
+      iex> datetime
+      #DateTime<2017-06-18 05:45:33Z>
+
+  """
+
+  alias Litmus.Required
+  alias Litmus.Type
+
+  defstruct required: false
+
+  @type t :: %__MODULE__{
+          required: boolean
+        }
+
+  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  def validate_field(type, field, data) do
+    with {:ok, data} <- Required.validate(type, field, data),
+         {:ok, data} <- convert(type, field, data) do
+      {:ok, data}
+    else
+      {:error, msg} -> {:error, msg}
+    end
+  end
+
+  @spec convert(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  defp convert(%__MODULE__{}, field, params) do
+    cond do
+      !Map.has_key?(params, field) ->
+        {:ok, params}
+
+      params[field] == nil ->
+        {:ok, params}
+
+      is_binary(params[field]) ->
+        case DateTime.from_iso8601(params[field]) do
+          {:ok, date_time, _utc_offset} -> {:ok, Map.put(params, field, date_time)}
+          {:error, _} -> error_tuple(field)
+        end
+
+      true ->
+        error_tuple(field)
+    end
+  end
+
+  @spec error_tuple(String.t()) :: {:error, String.t()}
+  defp error_tuple(field) do
+    {:error, "#{field} must be a valid ISO-8601 datetime"}
+  end
+
+  defimpl Litmus.Type do
+    alias Litmus.Type
+
+    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
+    def validate(type, field, data), do: Type.DateTime.validate_field(type, field, data)
+  end
+end

--- a/test/litmus/type/date_time_test.exs
+++ b/test/litmus/type/date_time_test.exs
@@ -1,0 +1,64 @@
+defmodule Litmus.Type.DateTimeTest do
+  use ExUnit.Case, async: true
+  doctest Litmus.Type.DateTime
+
+  alias Litmus.Type
+
+  @field "start_date"
+
+  describe "validate_field/3" do
+    test "converts a string to a datetime" do
+      data = %{@field => "1990-05-01T06:32:00Z"}
+
+      {:ok, expected_date_time, _} = DateTime.from_iso8601(data[@field])
+      expected_data = %{@field => expected_date_time}
+
+      type = %Type.DateTime{
+        required: true
+      }
+
+      assert Type.DateTime.validate_field(type, @field, data) == {:ok, expected_data}
+    end
+
+    test "does not alter nil" do
+      data = %{@field => nil}
+
+      type = %Type.DateTime{}
+
+      assert Type.DateTime.validate_field(type, @field, data) == {:ok, data}
+    end
+
+    test "errors when required datetime is not provided" do
+      data = %{}
+
+      type = %Type.DateTime{
+        required: true
+      }
+
+      assert Type.DateTime.validate_field(type, @field, data) ==
+               {:error, "start_date is required"}
+    end
+
+    test "errors when the value is not a string" do
+      data = %{@field => 1234}
+
+      type = %Type.DateTime{
+        required: true
+      }
+
+      assert Type.DateTime.validate_field(type, @field, data) ==
+               {:error, "start_date must be a valid ISO-8601 datetime"}
+    end
+
+    test "errors when the value is not in an ISO-8601 datetime with timezone format" do
+      data = %{@field => "2018-06-01"}
+
+      type = %Type.DateTime{
+        required: true
+      }
+
+      assert Type.DateTime.validate_field(type, @field, data) ==
+               {:error, "start_date must be a valid ISO-8601 datetime"}
+    end
+  end
+end

--- a/test/litmus_test.exs
+++ b/test/litmus_test.exs
@@ -37,22 +37,28 @@ defmodule LitmusTest do
           type: :number,
           min_length: 2,
           max_length: 5
-        }
+        },
+        "start_date" => %Litmus.Type.DateTime{}
       }
 
-      req_params = %{
+      params = %{
         "id" => "abc",
         "password" => " 1234 ",
         "user" => "qwerty",
         "pin" => 3636,
         "remember_me" => 1,
-        "account_ids" => [523, 524, 599]
+        "account_ids" => [523, 524, 599],
+        "start_date" => "1990-05-01T06:32:00Z"
       }
 
-      modified_params = Map.replace!(req_params, "password", String.trim(req_params["password"]))
-      modified_params = Map.replace!(modified_params, "remember_me", true)
+      modified_params = %{
+        params
+        | "password" => String.trim(params["password"]),
+          "remember_me" => true,
+          "start_date" => params["start_date"] |> DateTime.from_iso8601() |> elem(1)
+      }
 
-      assert Litmus.validate(req_params, login_schema) == {:ok, modified_params}
+      assert Litmus.validate(params, login_schema) == {:ok, modified_params}
     end
 
     test "errors when a disallowed parameter is passed" do
@@ -62,12 +68,12 @@ defmodule LitmusTest do
         }
       }
 
-      req_params = %{
+      params = %{
         "id" => "1",
         "abc" => true
       }
 
-      assert Litmus.validate(req_params, login_schema) == {:error, "abc is not allowed"}
+      assert Litmus.validate(params, login_schema) == {:error, "abc is not allowed"}
     end
   end
 end


### PR DESCRIPTION
### What

* Adds the `DateTime` type which supports ISO-8601 date times with time offset strings and converts them to `DateTime.t()`.

### Why

* This is a useful type to validate in APIs for parameters like `start_date`, etc.