### PR TITLE
 feat(datetime): allows DateTime structs for values and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ schema = %{
   "account_ids" => %Litmus.Type.List{
     max_length: 3,
     type: :number
+  },
+  "remember_me" => %Litmus.Type.Boolean{
+    default: false
   }
 }
 
@@ -64,7 +67,16 @@ params = %{
 }
 
 Litmus.validate(params, schema)
-# => {:ok, %{"id" => 1, "new_user" => true, "pin" => 1234, "username" => "user@123", "account_ids" => [1, 3, 9]}}
+# => {:ok,
+#      %{
+#        "id" => 1,
+#        "new_user" => true,
+#        "pin" => 1234,
+#        "username" => "user@123",
+#        "account_ids" => [1, 3, 9],
+#        "remember_me" => false
+#      }
+#    }
 
 Litmus.validate(%{}, schema)
 # => {:error, "id is required"}

--- a/lib/litmus/type/any.ex
+++ b/lib/litmus/type/any.ex
@@ -18,6 +18,10 @@ defmodule Litmus.Type.Any do
       iex> Litmus.validate(%{"id" => 1}, schema)
       {:ok, %{"id" => 1}}
 
+      iex> schema = %{"id" => %Litmus.Type.Any{default: "new_id"}}
+      iex> Litmus.validate(%{}, schema)
+      {:ok, %{"id" => "new_id"}}
+
       iex> schema = %{"id" => %Litmus.Type.Any{required: true}}
       iex> Litmus.validate(%{}, schema)
       {:error, "id is required"}

--- a/lib/litmus/type/boolean.ex
+++ b/lib/litmus/type/boolean.ex
@@ -25,14 +25,22 @@ defmodule Litmus.Type.Boolean do
   ## Examples
 
       iex> schema = %{
-      ...> "new_user" => %Litmus.Type.Boolean{
-      ...>   truthy: ["1"],
-      ...>   falsy: ["0"]
-      ...>  }
+      ...>   "new_user" => %Litmus.Type.Boolean{
+      ...>     truthy: ["1"],
+      ...>     falsy: ["0"]
+      ...>   }
       ...> }
       iex> params = %{"new_user" => "1"}
       iex> Litmus.validate(params, schema)
       {:ok, %{"new_user" => true}}
+
+      iex> schema = %{
+      ...>   "new_user" => %Litmus.Type.Boolean{
+      ...>     default: false
+      ...>   }
+      ...> }
+      iex> Litmus.validate(%{}, schema)
+      {:ok, %{"new_user" => false}}
 
       iex> schema = %{"new_user" => %Litmus.Type.Boolean{}}
       iex> params = %{"new_user" => 0}

--- a/lib/litmus/type/list.ex
+++ b/lib/litmus/type/list.ex
@@ -39,6 +39,14 @@ defmodule Litmus.Type.List do
       iex> Litmus.validate(%{"ids" => [1, "a"]}, schema)
       {:error, "ids must be a list of numbers"}
 
+      iex> schema = %{
+      ...>   "ids" => %Litmus.Type.List{
+      ...>     default: []
+      ...>   }
+      ...> }
+      iex> Litmus.validate(%{}, schema)
+      {:ok, %{"ids" => []}}
+
   """
 
   alias Litmus.{Default, Required}

--- a/lib/litmus/type/number.ex
+++ b/lib/litmus/type/number.ex
@@ -23,13 +23,13 @@ defmodule Litmus.Type.Number do
   ## Examples
 
       iex> schema = %{
-      ...> "id" => %Litmus.Type.Number{
-      ...>   integer: true
-      ...> },
-      ...> "gpa" => %Litmus.Type.Number{
-      ...>   min: 0,
-      ...>   max: 4
-      ...>  }
+      ...>   "id" => %Litmus.Type.Number{
+      ...>     integer: true
+      ...>   },
+      ...>   "gpa" => %Litmus.Type.Number{
+      ...>     min: 0,
+      ...>     max: 4
+      ...>   }
       ...> }
       iex> params = %{"id" => "123", "gpa" => 3.8}
       iex> Litmus.validate(params, schema)
@@ -37,6 +37,14 @@ defmodule Litmus.Type.Number do
       iex> params = %{"id" => "123.456", "gpa" => 3.8}
       iex> Litmus.validate(params, schema)
       {:error, "id must be an integer"}
+
+      iex> schema = %{
+      ...>   "gpa" => %Litmus.Type.Number{
+      ...>     default: 4
+      ...>   }
+      ...> }
+      iex> Litmus.validate(%{}, schema)
+      {:ok, %{"gpa" => 4}}
 
   """
 

--- a/lib/litmus/type/string.ex
+++ b/lib/litmus/type/string.ex
@@ -34,24 +34,32 @@ defmodule Litmus.Type.String do
   ## Examples
 
       iex> schema = %{
-      ...> "username" => %Litmus.Type.String{
-      ...>   min_length: 3,
-      ...>   max_length: 10,
-      ...>   trim: true
-      ...> },
-      ...> "password" => %Litmus.Type.String{
-      ...>   length: 6,
-      ...>   regex: %Litmus.Type.String.Regex{
-      ...>     pattern: ~r/^[a-zA-Z0-9_]*$/,
-      ...>     error_message: "password must be alphanumeric"
+      ...>   "username" => %Litmus.Type.String{
+      ...>     min_length: 3,
+      ...>     max_length: 10,
+      ...>     trim: true
+      ...>   },
+      ...>   "password" => %Litmus.Type.String{
+      ...>     length: 6,
+      ...>     regex: %Litmus.Type.String.Regex{
+      ...>       pattern: ~r/^[a-zA-Z0-9_]*$/,
+      ...>       error_message: "password must be alphanumeric"
+      ...>     }
       ...>   }
-      ...>  }
       ...> }
       iex> params = %{"username" => " user123 ", "password" => "root01"}
       iex> Litmus.validate(params, schema)
       {:ok, %{"username" => "user123", "password" => "root01"}}
       iex> Litmus.validate(%{"password" => "ro!_@1"}, schema)
       {:error, "password must be alphanumeric"}
+
+      iex> schema = %{
+      ...>   "username" => %Litmus.Type.String{
+      ...>     default: "anonymous"
+      ...>   }
+      ...> }
+      iex> Litmus.validate(%{}, schema)
+      {:ok, %{"username" => "anonymous"}}
 
   """
 

--- a/test/litmus/type/date_time_test.exs
+++ b/test/litmus/type/date_time_test.exs
@@ -28,6 +28,17 @@ defmodule Litmus.Type.DateTimeTest do
       assert Type.DateTime.validate_field(type, @field, data) == {:ok, data}
     end
 
+    test "allows DateTimes" do
+      {:ok, datetime, _} = DateTime.from_iso8601("1999-01-05T05:00:00Z")
+      data = %{@field => datetime}
+
+      type = %Type.DateTime{
+        required: true
+      }
+
+      assert Type.DateTime.validate_field(type, @field, data) == {:ok, data}
+    end
+
     test "errors when required datetime is not provided" do
       data = %{}
 


### PR DESCRIPTION
## What

* Adds more examples of using `default`.
* Adds support for DateTime structs for values and defaults for `Litmus.Type.DateTime`.
* Correctly formats examples with mis-formatted doctests.

## Why

* Examples make it easier for people to figure out how to use.
* It's nice to specify a DateTime default as an actual DateTime, not just an ISO-8601 string.
  * If someone performs the DateTime conversion on their own, it's nice to also allow DateTime structs to pass validation.