### PR TITLE
feat(string): adds replace

### DIFF
--- a/lib/litmus/type/string/replace.ex
+++ b/lib/litmus/type/string/replace.ex
@@ -1,0 +1,15 @@
+defmodule Litmus.Type.String.Replace do
+  @moduledoc false
+
+  defstruct [
+    :pattern,
+    :replacement,
+    global: true
+  ]
+
+  @type t :: %__MODULE__{
+          pattern: String.pattern() | Regex.t() | nil,
+          replacement: String.t() | nil,
+          global: boolean
+        }
+end

--- a/test/litmus/type/string_test.exs
+++ b/test/litmus/type/string_test.exs
@@ -358,6 +358,73 @@ defmodule Litmus.Type.StringTest do
     end
   end
 
+  describe "replace" do
+    test "replaces a pattern in a string with a new string" do
+      data = %{"username" => "user123"}
+      modified_data = %{"username" => "anonymous"}
+
+      schema = %{
+        "username" => %Litmus.Type.String{
+          replace: %Litmus.Type.String.Replace{
+            pattern: ~r/^user[0-9]*$/,
+            replacement: "anonymous"
+          }
+        }
+      }
+
+      assert Litmus.validate(data, schema) == {:ok, modified_data}
+    end
+
+    test "replaces multiple occurences of a regex within a string" do
+      data = %{"username" => "user123"}
+      modified_data = %{"username" => "userXXX"}
+
+      schema = %{
+        "username" => %Litmus.Type.String{
+          replace: %Litmus.Type.String.Replace{
+            pattern: ~r/[0-9]/,
+            replacement: "X"
+          }
+        }
+      }
+
+      assert Litmus.validate(data, schema) == {:ok, modified_data}
+    end
+
+    test "replaces multiple occurences of a string within a string" do
+      data = %{"username" => "user212"}
+      modified_data = %{"username" => "userX1X"}
+
+      schema = %{
+        "username" => %Litmus.Type.String{
+          replace: %Litmus.Type.String.Replace{
+            pattern: "2",
+            replacement: "X"
+          }
+        }
+      }
+
+      assert Litmus.validate(data, schema) == {:ok, modified_data}
+    end
+
+    test "replaces a single occurences of a patten when global is false" do
+      data = %{"username" => "user123"}
+      modified_data = %{"username" => "userX23"}
+
+      schema = %{
+        "username" => %Litmus.Type.String{
+          replace: %Litmus.Type.String.Replace{
+            pattern: ~r/[0-9]/,
+            replacement: "X",
+            global: false
+          }
+        }
+      }
+
+      assert Litmus.validate(data, schema) == {:ok, modified_data}
+    end
+  end
+
   describe "convert to string" do
     test "returns :ok with new parameters having values converted to string when field is boolean or number" do
       data = %{"id" => 1, "new_user" => true}


### PR DESCRIPTION
Adds a `:replace` option to the String schema type.

**NOTE: remember to remove `has_key?` after #28 has been merged.**