### PR TITLE
feat(required): exit early for non-required, non-present fields

### DIFF
--- a/lib/litmus/required.ex
+++ b/lib/litmus/required.ex
@@ -1,7 +1,7 @@
 defmodule Litmus.Required do
   @moduledoc false
 
-  @spec validate(map, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate(map, String.t(), map) :: {:ok | :ok_not_present, map} | {:error, String.t()}
   def validate(%{required: true}, field, params) do
     if Map.has_key?(params, field) && params[field] != nil do
       {:ok, params}
@@ -10,5 +10,11 @@ defmodule Litmus.Required do
     end
   end
 
-  def validate(%{required: false}, _field, params), do: {:ok, params}
+  def validate(%{required: false}, field, params) do
+    if Map.has_key?(params, field) do
+      {:ok, params}
+    else
+      {:ok_not_present, params}
+    end
+  end
 end

--- a/lib/litmus/type/any.ex
+++ b/lib/litmus/type/any.ex
@@ -44,10 +44,9 @@ defmodule Litmus.Type.Any do
 
   @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
-    with {:ok, data} <- Required.validate(type, field, data),
-         {:ok, data} <- Default.validate(type, field, data) do
-      {:ok, data}
-    else
+    case Required.validate(type, field, data) do
+      {:ok, data} -> {:ok, data}
+      {:ok_not_present, data} -> Default.validate(type, field, data)
       {:error, msg} -> {:error, msg}
     end
   end

--- a/lib/litmus/type/boolean.ex
+++ b/lib/litmus/type/boolean.ex
@@ -69,10 +69,10 @@ defmodule Litmus.Type.Boolean do
   @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
-         {:ok, data} <- Default.validate(type, field, data),
          {:ok, data} <- truthy_falsy_validate(type, field, data) do
       {:ok, data}
     else
+      {:ok_not_present, data} -> Default.validate(type, field, data)
       {:error, msg} -> {:error, msg}
     end
   end
@@ -100,9 +100,6 @@ defmodule Litmus.Type.Boolean do
   @spec truthy_falsy_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp truthy_falsy_validate(%__MODULE__{falsy: falsy, truthy: truthy}, field, params) do
     cond do
-      !Map.has_key?(params, field) ->
-        {:ok, params}
-
       params[field] == nil ->
         {:ok, params}
 

--- a/lib/litmus/type/date_time.ex
+++ b/lib/litmus/type/date_time.ex
@@ -8,8 +8,7 @@ defmodule Litmus.Type.DateTime do
 
     * `:default` - Setting `:default` will populate a field with the provided
       value, assuming that it is not present already. If a field already has a
-      value present, it will not be altered. The default can either be a `DateTime`
-      or an ISO-8601 string.
+      value present, it will not be altered.
 
     * `:required` - Setting `:required` to `true` will cause a validation error
       when a field is not present or the value is `nil`. Allowed values for
@@ -21,15 +20,6 @@ defmodule Litmus.Type.DateTime do
       iex> {:ok, %{"start_date" => datetime}} = Litmus.validate(%{"start_date" => "2017-06-18T05:45:33Z"}, schema)
       iex> datetime
       #DateTime<2017-06-18 05:45:33Z>
-
-      iex> schema = %{
-      ...>   "start_date" => %Litmus.Type.DateTime{
-      ...>     default: "2019-05-01T06:25:00-0700"
-      ...>   }
-      ...> }
-      iex> {:ok, %{"start_date" => datetime}} = Litmus.validate(%{}, schema)
-      iex> datetime
-      #DateTime<2019-05-01 13:25:00Z>
 
       iex> {:ok, default_datetime, _} = DateTime.from_iso8601("2019-05-01T06:25:00-0700")
       ...> schema = %{
@@ -57,10 +47,10 @@ defmodule Litmus.Type.DateTime do
   @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
-         {:ok, data} <- Default.validate(type, field, data),
          {:ok, data} <- convert(type, field, data) do
       {:ok, data}
     else
+      {:ok_not_present, data} -> Default.validate(type, field, data)
       {:error, msg} -> {:error, msg}
     end
   end
@@ -68,9 +58,6 @@ defmodule Litmus.Type.DateTime do
   @spec convert(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp convert(%__MODULE__{}, field, params) do
     cond do
-      !Map.has_key?(params, field) ->
-        {:ok, params}
-
       params[field] == nil ->
         {:ok, params}
 

--- a/lib/litmus/type/list.ex
+++ b/lib/litmus/type/list.ex
@@ -73,7 +73,6 @@ defmodule Litmus.Type.List do
   @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
-         {:ok, data} <- Default.validate(type, field, data),
          {:ok, data} <- validate_list(type, field, data),
          {:ok, data} <- type_validate(type, field, data),
          {:ok, data} <- min_length_validate(type, field, data),
@@ -81,6 +80,7 @@ defmodule Litmus.Type.List do
          {:ok, data} <- length_validate(type, field, data) do
       {:ok, data}
     else
+      {:ok_not_present, data} -> Default.validate(type, field, data)
       {:error, msg} -> {:error, msg}
     end
   end
@@ -88,9 +88,6 @@ defmodule Litmus.Type.List do
   @spec validate_list(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
   defp validate_list(%__MODULE__{}, field, params) do
     cond do
-      !Map.has_key?(params, field) ->
-        {:ok, params}
-
       params[field] == nil ->
         {:ok, params}
 
@@ -109,7 +106,7 @@ defmodule Litmus.Type.List do
 
   defp min_length_validate(%__MODULE__{min_length: min_length}, field, params)
        when is_integer(min_length) and min_length >= 0 do
-    if Map.has_key?(params, field) && length(params[field]) < min_length do
+    if length(params[field]) < min_length do
       {:error, "#{field} must not be below length of #{min_length}"}
     else
       {:ok, params}
@@ -123,7 +120,7 @@ defmodule Litmus.Type.List do
 
   defp max_length_validate(%__MODULE__{max_length: max_length}, field, params)
        when is_integer(max_length) and max_length >= 0 do
-    if Map.has_key?(params, field) && length(params[field]) > max_length do
+    if length(params[field]) > max_length do
       {:error, "#{field} must not exceed length of #{max_length}"}
     else
       {:ok, params}
@@ -137,7 +134,7 @@ defmodule Litmus.Type.List do
 
   defp length_validate(%__MODULE__{length: length}, field, params)
        when is_integer(length) and length >= 0 do
-    if Map.has_key?(params, field) && length(params[field]) != length do
+    if length(params[field]) != length do
       {:error, "#{field} length must be of #{length} length"}
     else
       {:ok, params}

--- a/lib/litmus/type/number.ex
+++ b/lib/litmus/type/number.ex
@@ -69,13 +69,13 @@ defmodule Litmus.Type.Number do
   @spec validate_field(t, binary, map) :: {:ok, map} | {:error, binary}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
-         {:ok, data} <- Default.validate(type, field, data),
          {:ok, data} <- convert(type, field, data),
          {:ok, data} <- min_validate(type, field, data),
          {:ok, data} <- max_validate(type, field, data),
          {:ok, data} <- integer_validate(type, field, data) do
       {:ok, data}
     else
+      {:ok_not_present, data} -> Default.validate(type, field, data)
       {:error, msg} -> {:error, msg}
     end
   end
@@ -83,9 +83,6 @@ defmodule Litmus.Type.Number do
   @spec convert(t, binary, map) :: {:ok, map} | {:error, binary}
   defp convert(%__MODULE__{}, field, params) do
     cond do
-      !Map.has_key?(params, field) ->
-        {:ok, params}
-
       params[field] == nil ->
         {:ok, params}
 
@@ -134,10 +131,10 @@ defmodule Litmus.Type.Number do
   end
 
   defp integer_validate(%__MODULE__{integer: true}, field, params) do
-    if Map.has_key?(params, field) && !is_integer(params[field]) do
-      {:error, "#{field} must be an integer"}
-    else
+    if is_integer(params[field]) do
       {:ok, params}
+    else
+      {:error, "#{field} must be an integer"}
     end
   end
 
@@ -148,7 +145,7 @@ defmodule Litmus.Type.Number do
 
   defp min_validate(%__MODULE__{min: min}, field, params)
        when is_number(min) do
-    if Map.has_key?(params, field) && params[field] < min do
+    if params[field] < min do
       {:error, "#{field} must be greater than or equal to #{min}"}
     else
       {:ok, params}
@@ -162,7 +159,7 @@ defmodule Litmus.Type.Number do
 
   defp max_validate(%__MODULE__{max: max}, field, params)
        when is_number(max) do
-    if Map.has_key?(params, field) && params[field] > max do
+    if params[field] > max do
       {:error, "#{field} must be less than or equal to #{max}"}
     else
       {:ok, params}

--- a/test/litmus/required_test.exs
+++ b/test/litmus/required_test.exs
@@ -45,7 +45,7 @@ defmodule Litmus.RequiredTest do
         required: false
       }
 
-      assert Required.validate(type, field, params) == {:ok, params}
+      assert Required.validate(type, field, params) == {:ok_not_present, params}
     end
   end
 end

--- a/test/litmus/type/any_test.exs
+++ b/test/litmus/type/any_test.exs
@@ -15,5 +15,14 @@ defmodule Litmus.Type.AnyTest do
 
       assert Type.Any.validate_field(type, field, data) == {:ok, data}
     end
+
+    test "does not error if the field is not provided and not required" do
+      field = "id"
+      data = %{}
+
+      type = %Type.Any{}
+
+      assert Type.Any.validate_field(type, field, data) == {:ok, data}
+    end
   end
 end

--- a/test/litmus/type/boolean_test.exs
+++ b/test/litmus/type/boolean_test.exs
@@ -24,6 +24,17 @@ defmodule Litmus.Type.BooleanTest do
 
       assert Type.Boolean.validate_field(type, field, data) == {:ok, data}
     end
+
+    test "does not error if the field is not provided and not required" do
+      field = "id"
+      data = %{}
+
+      type = %Type.Boolean{
+        truthy: [1, "One"]
+      }
+
+      assert Type.Boolean.validate_field(type, field, data) == {:ok, data}
+    end
   end
 
   describe "truthy validation" do

--- a/test/litmus/type/date_time_test.exs
+++ b/test/litmus/type/date_time_test.exs
@@ -71,5 +71,14 @@ defmodule Litmus.Type.DateTimeTest do
       assert Type.DateTime.validate_field(type, @field, data) ==
                {:error, "start_date must be a valid ISO-8601 datetime"}
     end
+
+    test "does not error if the field is not provided and not required" do
+      field = "id"
+      data = %{}
+
+      type = %Type.DateTime{}
+
+      assert Type.DateTime.validate_field(type, field, data) == {:ok, data}
+    end
   end
 end

--- a/test/litmus/type/list_test.exs
+++ b/test/litmus/type/list_test.exs
@@ -24,6 +24,18 @@ defmodule Litmus.Type.ListTest do
 
       assert Type.List.validate_field(type, field, data) == {:ok, data}
     end
+
+    test "does not error if the field is not provided and not required" do
+      field = "ids"
+      data = %{}
+
+      type = %Type.List{
+        length: 3,
+        type: :boolean
+      }
+
+      assert Type.List.validate_field(type, field, data) == {:ok, data}
+    end
   end
 
   describe "check if field is list" do

--- a/test/litmus/type/number_test.exs
+++ b/test/litmus/type/number_test.exs
@@ -15,6 +15,17 @@ defmodule Litmus.Type.NumberTest do
 
       assert Type.Number.validate_field(type, field, data) == {:ok, data}
     end
+
+    test "does not error if the field is not provided and not required" do
+      field = "id"
+      data = %{}
+
+      type = %Type.Number{
+        min: 3
+      }
+
+      assert Type.Number.validate_field(type, field, data) == {:ok, data}
+    end
   end
 
   describe "convert string to number" do

--- a/test/litmus/type/string_test.exs
+++ b/test/litmus/type/string_test.exs
@@ -88,6 +88,17 @@ defmodule Litmus.Type.StringTest do
                {:error,
                 "#{field} length must be greater than or equal to #{min_length} characters"}
     end
+
+    test "does not error if the field is not provided and not required" do
+      field = "id"
+      data = %{}
+
+      type = %Type.String{
+        min_length: 3
+      }
+
+      assert Type.String.validate_field(type, field, data) == {:ok, data}
+    end
   end
 
   describe "maximum length validation" do


### PR DESCRIPTION
Instead of having to have checks for each sub-validator like `Map.has_key?(params, field)`, we can exit early when a field is not-present, but not-required. In this case, we should use the default value provided in the schema, if present.

This simplifies a lot of the code, and makes it harder to create bugs for new validators in the future because they don't have to check for the field being present.

There is a breaking change here: the DateTime type no longer converts default ISO-8601 strings to DateTime structs automatically. This was inconsistent behavior from other types, and I don't think it's a necessity at this point, nor something someone would expect from this library