### PR TITLE
chore(typespecs): corrects field typespecs

### DIFF
--- a/lib/litmus/default.ex
+++ b/lib/litmus/default.ex
@@ -3,7 +3,7 @@ defmodule Litmus.Default do
 
   alias Litmus.Type.Any.NoDefault
 
-  @spec validate(map, String.t(), map) :: {:ok, map}
+  @spec validate(map, term, map) :: {:ok, map}
   def validate(%{default: default_value}, field, params) when default_value != NoDefault do
     {:ok, Map.put_new(params, field, default_value)}
   end

--- a/lib/litmus/required.ex
+++ b/lib/litmus/required.ex
@@ -1,7 +1,7 @@
 defmodule Litmus.Required do
   @moduledoc false
 
-  @spec validate(map, String.t(), map) :: {:ok | :ok_not_present, map} | {:error, String.t()}
+  @spec validate(map, term, map) :: {:ok | :ok_not_present, map} | {:error, String.t()}
   def validate(%{required: true}, field, params) do
     if Map.has_key?(params, field) && params[field] != nil do
       {:ok, params}

--- a/lib/litmus/type.ex
+++ b/lib/litmus/type.ex
@@ -11,6 +11,6 @@ defprotocol Litmus.Type do
           | Type.Number.t()
           | Type.String.t()
 
-  @spec validate(t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate(t(), term, map) :: {:ok, map} | {:error, String.t()}
   def validate(type, field, data)
 end

--- a/lib/litmus/type/any.ex
+++ b/lib/litmus/type/any.ex
@@ -42,7 +42,7 @@ defmodule Litmus.Type.Any do
           required: boolean
         }
 
-  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate_field(t, term, map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     case Required.validate(type, field, data) do
       {:ok, data} -> {:ok, data}
@@ -54,7 +54,7 @@ defmodule Litmus.Type.Any do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
+    @spec validate(Type.t(), term, map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.Any.validate_field(type, field, data)
   end
 end

--- a/lib/litmus/type/boolean.ex
+++ b/lib/litmus/type/boolean.ex
@@ -66,7 +66,7 @@ defmodule Litmus.Type.Boolean do
           required: boolean
         }
 
-  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate_field(t, term, map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
          {:ok, data} <- truthy_falsy_validate(type, field, data) do
@@ -97,7 +97,7 @@ defmodule Litmus.Type.Boolean do
     initial_value in Enum.uniq(additional_values ++ default_values)
   end
 
-  @spec truthy_falsy_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec truthy_falsy_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp truthy_falsy_validate(%__MODULE__{falsy: falsy, truthy: truthy}, field, params) do
     cond do
       params[field] == nil ->
@@ -117,7 +117,7 @@ defmodule Litmus.Type.Boolean do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
+    @spec validate(Type.t(), term, map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.Boolean.validate_field(type, field, data)
   end
 end

--- a/lib/litmus/type/date_time.ex
+++ b/lib/litmus/type/date_time.ex
@@ -44,7 +44,7 @@ defmodule Litmus.Type.DateTime do
           required: boolean
         }
 
-  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate_field(t, term, map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
          {:ok, data} <- convert(type, field, data) do
@@ -55,7 +55,7 @@ defmodule Litmus.Type.DateTime do
     end
   end
 
-  @spec convert(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec convert(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp convert(%__MODULE__{}, field, params) do
     cond do
       params[field] == nil ->
@@ -87,7 +87,7 @@ defmodule Litmus.Type.DateTime do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
+    @spec validate(Type.t(), term, map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.DateTime.validate_field(type, field, data)
   end
 end

--- a/lib/litmus/type/list.ex
+++ b/lib/litmus/type/list.ex
@@ -66,11 +66,11 @@ defmodule Litmus.Type.List do
           min_length: non_neg_integer | nil,
           max_length: non_neg_integer | nil,
           length: non_neg_integer | nil,
-          type: String.t() | atom | nil,
+          type: atom | nil,
           required: boolean
         }
 
-  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate_field(t, term, map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
          {:ok, data} <- validate_list(type, field, data),
@@ -85,7 +85,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec validate_list(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate_list(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp validate_list(%__MODULE__{}, field, params) do
     cond do
       params[field] == nil ->
@@ -99,7 +99,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec min_length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec min_length_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp min_length_validate(%__MODULE__{min_length: nil}, _field, params) do
     {:ok, params}
   end
@@ -113,7 +113,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec max_length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec max_length_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp max_length_validate(%__MODULE__{max_length: nil}, _field, params) do
     {:ok, params}
   end
@@ -127,7 +127,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec length_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp length_validate(%__MODULE__{length: nil}, _field, params) do
     {:ok, params}
   end
@@ -141,7 +141,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec type_validate(t, String.t() | atom, map) :: {:ok, map} | {:error, String.t()}
+  @spec type_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp type_validate(%__MODULE__{type: nil}, _field, params) do
     {:ok, params}
   end
@@ -155,7 +155,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec validate_atom(map, String.t()) :: {:ok, map} | {:error, String.t()}
+  @spec validate_atom(map, term) :: {:ok, map} | {:error, String.t()}
   defp validate_atom(params, field) do
     if Enum.all?(params[field], &is_atom/1) do
       {:ok, params}
@@ -164,7 +164,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec validate_boolean(map, String.t()) :: {:ok, map} | {:error, String.t()}
+  @spec validate_boolean(map, term) :: {:ok, map} | {:error, String.t()}
   defp validate_boolean(params, field) do
     if Enum.all?(params[field], &is_boolean/1) do
       {:ok, params}
@@ -173,7 +173,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec validate_number(map, String.t()) :: {:ok, map} | {:error, String.t()}
+  @spec validate_number(map, term) :: {:ok, map} | {:error, String.t()}
   defp validate_number(params, field) do
     if Enum.all?(params[field], &is_number/1) do
       {:ok, params}
@@ -182,7 +182,7 @@ defmodule Litmus.Type.List do
     end
   end
 
-  @spec validate_string(map, String.t()) :: {:ok, map} | {:error, String.t()}
+  @spec validate_string(map, term) :: {:ok, map} | {:error, String.t()}
   defp validate_string(params, field) do
     if Enum.all?(params[field], &is_binary/1) do
       {:ok, params}
@@ -194,7 +194,7 @@ defmodule Litmus.Type.List do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
+    @spec validate(Type.t(), term, map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.List.validate_field(type, field, data)
   end
 end

--- a/lib/litmus/type/number.ex
+++ b/lib/litmus/type/number.ex
@@ -66,7 +66,7 @@ defmodule Litmus.Type.Number do
 
   alias Litmus.{Default, Required}
 
-  @spec validate_field(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec validate_field(t, term, map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
          {:ok, data} <- convert(type, field, data),
@@ -80,7 +80,7 @@ defmodule Litmus.Type.Number do
     end
   end
 
-  @spec convert(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec convert(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp convert(%__MODULE__{}, field, params) do
     cond do
       params[field] == nil ->
@@ -125,7 +125,7 @@ defmodule Litmus.Type.Number do
     end
   end
 
-  @spec integer_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec integer_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp integer_validate(%__MODULE__{integer: false}, _field, params) do
     {:ok, params}
   end
@@ -138,7 +138,7 @@ defmodule Litmus.Type.Number do
     end
   end
 
-  @spec min_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec min_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp min_validate(%__MODULE__{min: nil}, _field, params) do
     {:ok, params}
   end
@@ -152,7 +152,7 @@ defmodule Litmus.Type.Number do
     end
   end
 
-  @spec max_validate(t, binary, map) :: {:ok, map} | {:error, binary}
+  @spec max_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp max_validate(%__MODULE__{max: nil}, _field, params) do
     {:ok, params}
   end
@@ -169,7 +169,7 @@ defmodule Litmus.Type.Number do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), binary, map) :: {:ok, map} | {:error, binary}
+    @spec validate(Type.t(), term, map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.Number.validate_field(type, field, data)
   end
 end

--- a/lib/litmus/type/string.ex
+++ b/lib/litmus/type/string.ex
@@ -86,7 +86,7 @@ defmodule Litmus.Type.String do
           required: boolean
         }
 
-  @spec validate_field(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec validate_field(t, term, map) :: {:ok, map} | {:error, String.t()}
   def validate_field(type, field, data) do
     with {:ok, data} <- Required.validate(type, field, data),
          {:ok, data} <- convert(type, field, data),
@@ -102,7 +102,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec convert(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec convert(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp convert(%__MODULE__{}, field, params) do
     cond do
       params[field] == nil ->
@@ -119,7 +119,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec min_length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec min_length_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp min_length_validate(%__MODULE__{min_length: min_length}, field, params)
        when is_integer(min_length) and min_length > 0 do
     if params[field] == nil or String.length(params[field]) < min_length do
@@ -133,7 +133,7 @@ defmodule Litmus.Type.String do
     {:ok, params}
   end
 
-  @spec max_length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec max_length_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp max_length_validate(%__MODULE__{max_length: nil}, _field, params) do
     {:ok, params}
   end
@@ -147,7 +147,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec length_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec length_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp length_validate(%__MODULE__{length: nil}, _field, params) do
     {:ok, params}
   end
@@ -168,7 +168,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec regex_validate(t, String.t(), map) :: {:ok, map} | {:error, String.t()}
+  @spec regex_validate(t, term, map) :: {:ok, map} | {:error, String.t()}
   defp regex_validate(%__MODULE__{regex: %{pattern: nil}}, _field, params) do
     {:ok, params}
   end
@@ -182,7 +182,7 @@ defmodule Litmus.Type.String do
     end
   end
 
-  @spec trim(t, String.t(), map) :: {:ok, map}
+  @spec trim(t, term, map) :: {:ok, map}
   defp trim(%__MODULE__{trim: true}, field, params) do
     if Map.get(params, field) do
       trimmed_value = String.trim(params[field])
@@ -200,7 +200,7 @@ defmodule Litmus.Type.String do
   defimpl Litmus.Type do
     alias Litmus.Type
 
-    @spec validate(Type.t(), String.t(), map) :: {:ok, map} | {:error, String.t()}
+    @spec validate(Type.t(), term, map) :: {:ok, map} | {:error, String.t()}
     def validate(type, field, data), do: Type.String.validate_field(type, field, data)
   end
 end


### PR DESCRIPTION
This PR cleans up some typespecs. `field`s can be more than just `String.t()`, so I changed those to `term` which is synonymous with `any`, but is used commonly in the standard library for things like `field`s or `key`s.